### PR TITLE
Removed hhvm and added php version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - hhvm
+  - 7.0
+  - 7.1
+  - 7.2
 
 before_script:
     - curl -s http://getcomposer.org/installer | php


### PR DESCRIPTION
I've removed hhvm because it is the one that is failing and because of the fact that hhvm is not supporting php anymore.
I've added php verison 7.0, 7.1 and 7.2.